### PR TITLE
feat: 为粒子添加 size, light, gravity, friction 属性

### DIFF
--- a/src/main/java/net/hackermdch/exparticle/inject/ParticleInj.java
+++ b/src/main/java/net/hackermdch/exparticle/inject/ParticleInj.java
@@ -56,4 +56,28 @@ public interface ParticleInj extends IParticle {
     default boolean isManaged() {
         throw new NotImplementedException();
     }
+
+    default void setCustomSize(double size) {
+        throw new NotImplementedException();
+    }
+
+    default double getCustomSize() {
+        throw new NotImplementedException();
+    }
+
+    default void setCustomLight(double light) {
+        throw new NotImplementedException();
+    }
+
+    default double getCustomLight() {
+        throw new NotImplementedException();
+    }
+
+    default void setGravity(float gravity) {
+        throw new NotImplementedException();
+    }
+
+    default void setFriction(float friction) {
+        throw new NotImplementedException();
+    }
 }

--- a/src/main/java/net/hackermdch/exparticle/mixin/ParticleMixin.java
+++ b/src/main/java/net/hackermdch/exparticle/mixin/ParticleMixin.java
@@ -7,6 +7,9 @@ import net.minecraft.client.particle.Particle;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Particle.class)
 public abstract class ParticleMixin implements IParticle {
@@ -34,6 +37,10 @@ public abstract class ParticleMixin implements IParticle {
     private double preZ;
     @Unique
     private boolean managed;
+    @Unique
+    private double customSize = Double.NaN;
+    @Unique
+    private double customLight = Double.NaN;
 
     public void setExe(IExecutable exe) {
         this.exe = exe;
@@ -75,6 +82,30 @@ public abstract class ParticleMixin implements IParticle {
         this.stop = stop;
     }
 
+    public void setCustomSize(double size) {
+        this.customSize = size * 0.125;
+    }
+
+    public double getCustomSize() {
+        return this.customSize;
+    }
+
+    public void setCustomLight(double light) {
+        customLight = Double.isNaN(light) ? Double.NaN : ((int)(light * 255) & 0xFF) / 255.0;
+    }
+
+    public double getCustomLight() {
+        return this.customLight;
+    }
+
+    public void setGravity(float gravity) {
+        this.gravity = gravity;
+    }
+
+    public void setFriction(float friction) {
+        this.friction = friction;
+    }
+
     public void customTick() {
         preX = x;
         preY = y;
@@ -99,16 +130,18 @@ public abstract class ParticleMixin implements IParticle {
                 data.ds1 = Math.atan2(z - centerZ, x - centerX);
                 data.ds2 = Math.atan2(y - centerY, Math.hypot(x - centerX, z - centerZ));
             }
-            data.vx = Double.NaN;
-            data.vy = Double.NaN;
-            data.vz = Double.NaN;
+            data.vx = this.xd;
+            data.vy = this.yd;
+            data.vz = this.zd;
             data.x = x - centerX;
             data.y = y - centerY;
             data.z = z - centerZ;
+            data.size = customSize;
             data.cr = rCol;
             data.cg = gCol;
             data.cb = bCol;
             data.alpha = alpha;
+            data.light = customLight;
             data.dis = Math.sqrt((x - centerX) * (x - centerX) + (y - centerY) * (y - centerY) + (z - centerZ) * (z - centerZ));
             data.s1 = Math.atan2(z - centerZ, x - centerX);
             data.s2 = Math.atan2(y - centerY, Math.hypot(x - centerX, z - centerZ));
@@ -124,6 +157,12 @@ public abstract class ParticleMixin implements IParticle {
             if (data.destroy != 0.0) {
                 remove();
                 return;
+            }
+            if (!Double.isNaN(data.size) && data.size != customSize) {
+                setCustomSize(data.size);
+            }
+            if (!Double.isNaN(data.light) && data.light != customLight) {
+                setCustomLight(data.light);
             }
             if (!Double.isNaN(data.vx) || !Double.isNaN(data.vy) || !Double.isNaN(data.vz)) {
                 setPos(preX, preY, preZ);
@@ -154,6 +193,16 @@ public abstract class ParticleMixin implements IParticle {
         return !Double.isNaN(num) ? num : (double) 0.0F;
     }
 
+    @Inject(method = "getLightColor", at = @At("HEAD"), cancellable = true)
+    protected void onGetLightColor(float partialTick, CallbackInfoReturnable<Integer> cir) {
+        double custom = this.getCustomLight();
+        if (!Double.isNaN(custom)) {
+            int block = (int) (custom * 15);
+            int sky = (int) (custom * 15);
+            cir.setReturnValue((sky << 20) | (block << 4));
+        }
+    }
+
     @Shadow
     public abstract void tick();
 
@@ -173,6 +222,12 @@ public abstract class ParticleMixin implements IParticle {
     @Shadow
     public double z;
     @Shadow
+    public double xd;
+    @Shadow
+    public double yd;
+    @Shadow
+    public double zd;
+    @Shadow
     public float rCol = 1.0F;
     @Shadow
     public float gCol = 1.0F;
@@ -180,4 +235,8 @@ public abstract class ParticleMixin implements IParticle {
     public float bCol = 1.0F;
     @Shadow
     public float alpha = 1.0F;
+    @Shadow
+    protected float gravity;
+    @Shadow
+    protected float friction;
 }

--- a/src/main/java/net/hackermdch/exparticle/mixin/SimpleAnimatedParticleMixin.java
+++ b/src/main/java/net/hackermdch/exparticle/mixin/SimpleAnimatedParticleMixin.java
@@ -4,6 +4,7 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.SimpleAnimatedParticle;
 import net.minecraft.client.particle.TextureSheetParticle;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -17,5 +18,10 @@ public abstract class SimpleAnimatedParticleMixin extends TextureSheetParticle {
     @Inject(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/particle/SimpleAnimatedParticle;setAlpha(F)V"), cancellable = true)
     private void onSetAlpha(CallbackInfo ci) {
         if (isManaged()) ci.cancel();
+    }
+
+    @Overwrite
+    public int getLightColor(float partialTick) {
+        return super.getLightColor(partialTick);
     }
 }

--- a/src/main/java/net/hackermdch/exparticle/mixin/SingleQuadParticleMixin.java
+++ b/src/main/java/net/hackermdch/exparticle/mixin/SingleQuadParticleMixin.java
@@ -1,0 +1,22 @@
+package net.hackermdch.exparticle.mixin;
+
+import net.hackermdch.exparticle.util.IParticle;
+import net.minecraft.client.particle.SingleQuadParticle;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(SingleQuadParticle.class)
+public abstract class SingleQuadParticleMixin implements IParticle {
+    @Shadow protected float quadSize;
+
+    @Inject(method = "getQuadSize", at = @At("HEAD"), cancellable = true)
+    private void onGetQuadSize(float scaleFactor, CallbackInfoReturnable<Float> cir) {
+        double custom = this.getCustomSize();
+        if (!Double.isNaN(custom)) {
+            cir.setReturnValue((float) custom);
+        }
+    }
+}

--- a/src/main/java/net/hackermdch/exparticle/util/IParticle.java
+++ b/src/main/java/net/hackermdch/exparticle/util/IParticle.java
@@ -26,4 +26,16 @@ public interface IParticle {
     void setManaged(boolean val);
 
     boolean isManaged();
+
+    double getCustomSize();
+
+    void setCustomSize(double size);
+
+    double getCustomLight();
+
+    void setCustomLight(double light);
+
+    void setGravity(float gravity);
+
+    void setFriction(float friction);
 }

--- a/src/main/java/net/hackermdch/exparticle/util/ParticleStruct.java
+++ b/src/main/java/net/hackermdch/exparticle/util/ParticleStruct.java
@@ -10,13 +10,18 @@ public class ParticleStruct {
     public double s2;
     public double dis;
     public double t;
+    public double size = 1.0;
     public double cr = 1.0;
     public double cg = 1.0;
     public double cb = 1.0;
     public double alpha = 1.0;
-    public double vx;
-    public double vy;
-    public double vz;
+    public double light = 1.0;
+    public double vx = 0.0;
+    public double vy = 0.0;
+    public double vz = 0.0;
+    public double gravity = 0.0;
+    public double friction = 1.0;
+    public double age = 0.0;
     public double cx;
     public double cy;
     public double cz;
@@ -26,6 +31,5 @@ public class ParticleStruct {
     public double ds1;
     public double ds2;
     public double ddis;
-    public double age;
     public double destroy;
 }

--- a/src/main/java/net/hackermdch/exparticle/util/ParticleUtil.java
+++ b/src/main/java/net/hackermdch/exparticle/util/ParticleUtil.java
@@ -34,6 +34,7 @@ public class ParticleUtil {
                     particle.yd = vy;
                     particle.zd = vz;
                 }
+                particle.setGravity(0.0f);
                 particle.setCenterX(cx);
                 particle.setCenterY(cy);
                 particle.setCenterZ(cz);

--- a/src/main/resources/exparticle.mixins.json
+++ b/src/main/resources/exparticle.mixins.json
@@ -9,7 +9,8 @@
   "client": [
     "ParticleEngineMixin",
     "ParticleMixin",
-    "SimpleAnimatedParticleMixin"
+    "SimpleAnimatedParticleMixin",
+    "SingleQuadParticleMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
# 为粒子添加 size, light, gravity, friction 属性

## 变更说明
为粒子系统增加四个可自定义的属性：**尺寸（size）**、**光照（light）**、**重力（gravity）** 和 **摩擦系数（friction）**。这些属性可通过命令参数或表达式动态控制，并为后续自定义命令（如 `custom-parameter`）提供基础支持。

## 具体修改
### 1. 接口与基础结构
- `IParticle` 接口新增方法：`getCustomSize/setCustomSize`, `getCustomLight/setCustomLight`, `setGravity`, `setFriction`。
- `ParticleInj` 添加对应的默认实现（抛异常，供其他注入类实现）。
- `ParticleStruct` 新增字段：`size`, `light`, `gravity`, `friction`, `age`，并为 `vx/vy/vz` 设置默认值 `0.0`。

### 2. Mixin 实现
- **`ParticleMixin`**：
  - 添加字段 `customSize` 和 `customLight`，默认值为 `Double.NaN`（表示未设置）。
  - 实现接口方法，`setCustomSize` 将输入值乘以 `0.125` 后存储（适配原版粒子大小缩放因子），`setCustomLight` 将 `0~1` 的输入映射为 `0~255` 并归一化，同时支持 `NaN`。
  - 在 `customMove` 中，将当前 `customSize` 和 `customLight` 写入 `data` 对象，供表达式使用；同时根据表达式结果更新粒子的实际属性。
  - 添加 `@Inject` 到 `getLightColor`，当 `customLight` 不为 `NaN` 时，用其覆盖原版光照计算。
- **`SingleQuadParticleMixin`**（新增）：覆盖 `getQuadSize` 方法，当 `customSize` 不为 `NaN` 时返回自定义大小。
- **`SimpleAnimatedParticleMixin`**：添加 `@Overwrite getLightColor`，确保调用父类方法，使光照覆盖生效。

### 3. 粒子生成基础调整
- 在 `ParticleUtil.spawnParticle` 中，新增 `particle.setGravity(0.0f);`，使所有由模组生成的粒子默认不受重力影响（后续可通过表达式或命令自定义）。

### 4. 配置文件
- `exparticle.mixins.json` 添加 `SingleQuadParticleMixin` 到 `client` 列表。

## 后续依赖
此 PR 是后续两个 PR（`CustomParticleBuilder` 和自定义命令系列）的基础，请先合并此 PR。

## 许可证
我同意以 LGPL-3.0 许可证贡献此代码。