### PR TITLE
添加三元运算符支持

### DIFF
--- a/src/main/java/net/hackermdch/exparticle/util/CodeGen.java
+++ b/src/main/java/net/hackermdch/exparticle/util/CodeGen.java
@@ -115,6 +115,8 @@ public class CodeGen {
                     codeGenTypeTransform(codeGenFunctionCallExp(functionCallExp.name, functionCallExp.args), targetType);
             case Expression.AssignExp assignExp ->
                     codeGenTypeTransform(codeGenAssignExp(assignExp.varList, assignExp.expList, targetType != T_VOID), targetType);
+            case Expression.TernaryExp ternaryExp ->
+                    codeGenTypeTransform(codeGenTernaryExp(ternaryExp), targetType);
             case null, default -> T_VOID;
         };
     }
@@ -591,6 +593,8 @@ public class CodeGen {
                     ++j;
                 }
             }
+        } else {
+            maxSimilarityIndex = 0;
         }
         if (maxSimilarityIndex == T_UNKNOW) throw new RuntimeException("function not found: " + name);
         var method = methods.get(maxSimilarityIndex);
@@ -672,6 +676,66 @@ public class CodeGen {
         }
         if (needReturn) codeGenNameExp("__RETURN");
         return needReturn ? types[expList.length - 1] : T_VOID;
+    }
+
+    // 生成三元表达式的字节码
+    private int codeGenTernaryExp(Expression.TernaryExp exp) {
+        // 若尚未确定返回类型，通过模拟计算分支类型并统一
+        if (exp.returnType == T_UNKNOW) {
+            startSimulation();
+            int t1 = codeGenExp(exp.trueExp, T_UNKNOW);
+            int t2 = codeGenExp(exp.falseExp, T_UNKNOW);
+            stopSimulation();
+
+            // 类型提升规则：int + int = int，其他数值组合提升为 double
+            if (t1 == T_INT && t2 == T_INT) {
+                exp.returnType = T_INT;
+            } else if ((t1 == T_INT || t1 == T_DOUBLE) && (t2 == T_INT || t2 == T_DOUBLE)) {
+                exp.returnType = T_DOUBLE;
+            } else {
+                // 目前仅支持数值类型，遇到矩阵等类型时抛出明确异常
+                throw new RuntimeException("Ternary operator only supports numeric types (int/double), got: " + t1 + " and " + t2);
+            }
+        }
+
+        int targetType = exp.returnType;
+
+        // 生成条件表达式，强制转为 int（0/1）
+        int condType = codeGenExp(exp.cond, T_INT); // 条件强制转换为int
+        Label falseLabel = new Label();
+        Label endLabel = new Label();
+
+        mv.visitJumpInsn(IFEQ, falseLabel); // if (条件 == 0) 跳转到 falseLabel
+
+        // 真分支
+        int trueType = codeGenExp(exp.trueExp, targetType);
+        int resultVar = maxLocal;                 // 分配临时变量槽位
+        if (targetType == T_DOUBLE) {
+            mv.visitVarInsn(DSTORE, resultVar);   // 存储 double
+            maxLocal += 2;
+        } else {
+            mv.visitVarInsn(ISTORE, resultVar);   // 存储 int
+            maxLocal += 1;
+        }
+        mv.visitJumpInsn(GOTO, endLabel);         // 跳过假分支
+
+        // 假分支
+        mv.visitLabel(falseLabel);
+        int falseType = codeGenExp(exp.falseExp, targetType);
+        if (targetType == T_DOUBLE) {
+            mv.visitVarInsn(DSTORE, resultVar);
+        } else {
+            mv.visitVarInsn(ISTORE, resultVar);
+        }
+
+        // 合并
+        mv.visitLabel(endLabel);
+        if (targetType == T_DOUBLE) {
+            mv.visitVarInsn(DLOAD, resultVar);   // 加载结果（double）
+        } else {
+            mv.visitVarInsn(ILOAD, resultVar);   // 加载结果（int）
+        }
+        return targetType;
     }
 
     private int codeGenTypeTransform(int sourceType, int targetType) {

--- a/src/main/java/net/hackermdch/exparticle/util/EnumToken.java
+++ b/src/main/java/net/hackermdch/exparticle/util/EnumToken.java
@@ -26,6 +26,8 @@ public enum EnumToken {
     GE(">="),
     EQ("=="),
     NEQ("!="),
+    QUESTION("?"),
+    COLON(":"),
     NUMBER,
     IDENTIFIER;
 

--- a/src/main/java/net/hackermdch/exparticle/util/Expression.java
+++ b/src/main/java/net/hackermdch/exparticle/util/Expression.java
@@ -231,4 +231,22 @@ public class Expression {
             return sb.deleteCharAt(sb.length() - 1).toString();
         }
     }
+
+    // 三元表达式节点
+    public static class TernaryExp extends Expression {
+        public final Expression cond;     // 条件表达式
+        public final Expression trueExp;  // 真分支
+        public final Expression falseExp; // 假分支
+
+        public TernaryExp(int line, Expression cond, Expression trueExp, Expression falseExp) {
+            super(line, T_UNKNOW);         // 类型未知，延迟到代码生成时确定
+            this.cond = cond;
+            this.trueExp = trueExp;
+            this.falseExp = falseExp;
+        }
+
+        public String toString() {
+            return cond.toString() + "?" + trueExp.toString() + ":" + falseExp.toString();
+        }
+    }
 }

--- a/src/main/java/net/hackermdch/exparticle/util/Lexer.java
+++ b/src/main/java/net/hackermdch/exparticle/util/Lexer.java
@@ -154,6 +154,12 @@ public class Lexer {
                     case '|':
                         this.skip(1);
                         return new Token(this.line, EnumToken.OR);
+                    case '?':
+                        this.skip(1);
+                        return new Token(this.line, EnumToken.QUESTION);
+                    case ':':
+                        this.skip(1);
+                        return new Token(this.line, EnumToken.COLON);
                     default:
                         if (ch != '.' && !this.isDigit(ch)) {
                             if (ch != '_' && !this.isLatter(ch)) {

--- a/src/main/java/net/hackermdch/exparticle/util/Optimize.java
+++ b/src/main/java/net/hackermdch/exparticle/util/Optimize.java
@@ -171,6 +171,24 @@ public class Optimize {
         }
     }
 
+    // 三元表达式的常量折叠优化
+    public static Expression optimizeTernary(Expression.TernaryExp exp) {
+        // 如果条件为常量，直接折叠
+        if (exp.cond instanceof Expression.IntegerExp) {          // 条件为整数常量
+            int condVal = ((Expression.IntegerExp) exp.cond).val;
+            return condVal != 0 ? exp.trueExp : exp.falseExp;
+        } else if (exp.cond instanceof Expression.FloatExp) {     // 条件为浮点常量
+            double condVal = ((Expression.FloatExp) exp.cond).val;
+            return condVal != 0.0 ? exp.trueExp : exp.falseExp;
+        }
+        // 如果真/假分支完全相同，返回其中一个
+        if (exp.trueExp == exp.falseExp) {
+            return exp.trueExp;
+        }
+        // 其他优化（如同类型常量计算）可以后续扩展
+        return exp;
+    }
+
     private static boolean trueOnly(Expression exp) {
         if (exp instanceof Expression.IntegerExp) {
             return ((Expression.IntegerExp) exp).val != 0;

--- a/src/main/java/net/hackermdch/exparticle/util/Parser.java
+++ b/src/main/java/net/hackermdch/exparticle/util/Parser.java
@@ -86,7 +86,7 @@ public class Parser {
     }
 
     private static Expression parseExp(Lexer lexer) {
-        return parseExp7(lexer);
+        return parseExp8(lexer);
     }
 
     private static Expression parseIdentifier(Lexer lexer) {
@@ -194,6 +194,18 @@ public class Parser {
             }
         }
         return false;
+    }
+
+    private static Expression parseExp8(Lexer lexer) {
+        Expression exp = parseExp7(lexer);
+        if (lexer.peekToken().enumToken == EnumToken.QUESTION) {
+            Token qToken = lexer.nextToken();
+            Expression trueExp = parseExp7(lexer);
+            lexer.nextToken(EnumToken.COLON);
+            Expression falseExp = parseExp8(lexer);
+            exp = Optimize.optimizeTernary(new Expression.TernaryExp(qToken.line, exp, trueExp, falseExp));
+        }
+        return exp;
     }
 
     private static Expression parseExp7(Lexer lexer) {


### PR DESCRIPTION
# 添加三元运算符支持

## 概述
为表达式系统增加了三元运算符（`? :`）的支持，允许在粒子参数表达式、自定义函数等场景中使用类似 `cond ? trueExpr : falseExpr` 的条件选择语法。该运算符遵循 C/Java 风格的右结合规则，类型提升规则与二元算术运算一致。

## 主要改动

### 1. 词法分析器 (`Lexer.java`)
- 添加对 `?` 和 `:` 字符的识别，生成对应的 `EnumToken.QUESTION` 和 `EnumToken.COLON`。

### 2. 语法分析器 (`Parser.java`)
- 新增优先级层 `parseExp8`，将三元运算符置于逻辑或（`parseExp7`）之上，实现右结合解析。
- 修改 `parseExp` 入口，使其调用 `parseExp8` 以确保三元运算符能被正确识别。

### 3. 抽象语法树 (`Expression.java`)
- 新增 `TernaryExp` 节点类，包含条件、真分支和假分支三个子表达式。
- 构造函数中将返回类型设为 `T_UNKNOW`，类型推断推迟到代码生成阶段（与二元运算设计统一）。

### 4. 常量折叠优化 (`Optimize.java`)
- 增加 `optimizeTernary` 方法，在编译期对常量条件进行折叠：
  - 若条件为常量整数或浮点数，直接替换为对应的分支。
  - 若真/假分支为同一表达式，则替换为单个表达式。

### 5. 字节码生成 (`CodeGen.java`)
- 在 `codeGenExp` 中增加对 `TernaryExp` 的分支处理，调用新增的 `codeGenTernaryExp` 方法。
- `codeGenTernaryExp` 实现：
  - 通过模拟计算确定两个分支的公共类型（仅支持 `int` 和 `double`，不符合时抛出明确异常）。
  - 生成条件跳转指令，将两个分支的结果分别存入临时局部变量，最后加载合并。
  - 类型提升规则：`int` + `int` → `int`，其他数值组合 → `double`。

### 6. 修复 (`CodeGen.java`)
- 在 `CodeGen.codeGenFunctionCallExp` 中添加 `maxSimilarityIndex = 0;`，用于处理函数调用时参数列表为空的情况（如 `random()`）。

## 影响范围
- 所有使用表达式的地方（如 `/particlex parameter` 的表达式参数、自定义函数体）均可使用三元运算符。
- 与现有二元运算符、函数调用等语法无缝集成，无需修改已有表达式。

## 测试
```
x > 0 ? 1 : -1
(t < 0) ? sin(t) : t^2
```

## 许可证
我同意以 LGPL-3.0 许可证贡献此代码。