### PR TITLE
feat: 使三元运算符支持矩阵类型 (int[][] 和 double[][])

### DIFF
--- a/src/main/java/net/hackermdch/exparticle/util/CodeGen.java
+++ b/src/main/java/net/hackermdch/exparticle/util/CodeGen.java
@@ -685,8 +685,11 @@ public class CodeGen {
             stopSimulation();
             if (t1 == T_INT && t2 == T_INT) exp.returnType = T_INT;
             else if ((t1 == T_INT || t1 == T_DOUBLE) && (t2 == T_INT || t2 == T_DOUBLE)) exp.returnType = T_DOUBLE;
+            else if (t1 == T_INTMAT && t2 == T_INTMAT) exp.returnType = T_INTMAT;
+            else if (t1 == T_DOUBLEMAT && t2 == T_DOUBLEMAT) exp.returnType = T_DOUBLEMAT;
+            else if ((t1 == T_INTMAT || t1 == T_DOUBLEMAT) && (t2 == T_INTMAT || t2 == T_DOUBLEMAT)) exp.returnType = T_DOUBLEMAT;
             else
-                throw new RuntimeException("Ternary operator only supports numeric types (int/double), got: " + t1 + " and " + t2);
+                throw new RuntimeException("Ternary operator only supports numeric or matrix types, got: " + t1 + " and " + t2);
         }
         var targetType = exp.returnType;
         var falseLabel = new Label();
@@ -698,6 +701,9 @@ public class CodeGen {
         if (targetType == T_DOUBLE) {
             mv.visitVarInsn(DSTORE, resultVar);
             maxLocal += 2;
+        } else if (targetType == T_INTMAT || targetType == T_DOUBLEMAT) {
+            mv.visitVarInsn(ASTORE, resultVar);
+            maxLocal += 1;
         } else {
             mv.visitVarInsn(ISTORE, resultVar);
             maxLocal += 1;
@@ -706,9 +712,11 @@ public class CodeGen {
         mv.visitLabel(falseLabel);
         codeGenExp(exp.falseExp, targetType);
         if (targetType == T_DOUBLE) mv.visitVarInsn(DSTORE, resultVar);
+        else if (targetType == T_INTMAT || targetType == T_DOUBLEMAT) mv.visitVarInsn(ASTORE, resultVar);
         else mv.visitVarInsn(ISTORE, resultVar);
         mv.visitLabel(endLabel);
         if (targetType == T_DOUBLE) mv.visitVarInsn(DLOAD, resultVar);
+        else if (targetType == T_INTMAT || targetType == T_DOUBLEMAT) mv.visitVarInsn(ALOAD, resultVar);
         else mv.visitVarInsn(ILOAD, resultVar);
         return targetType;
     }


### PR DESCRIPTION
# 使三元运算符支持矩阵类型 (int[][] 和 double[][])

## 变更内容
- 修改 `CodeGen.codeGenTernaryExp` 方法，增加对 `T_INTMAT` 和 `T_DOUBLEMAT` 类型的支持
- 当两个分支均为矩阵时，返回值类型自动推断：
  - 两个 `int[][]` → `int[][]`
  - 两个 `double[][]` → `double[][]`
  - 一个 `int[][]` 一个 `double[][]` → `double[][]`
- 保持原有数值类型行为不变
- 在代码生成中正确使用 `ASTORE`/`ALOAD` 处理矩阵引用

## 许可证
我同意以 LGPL-3.0 许可证贡献此代码。